### PR TITLE
[chore] binary tar need DISCLAIMER file

### DIFF
--- a/src/main/assembly/dolphinscheduler-binary.xml
+++ b/src/main/assembly/dolphinscheduler-binary.xml
@@ -35,7 +35,7 @@
 			<outputDirectory>bin</outputDirectory>
 		</fileSet>
 		<fileSet>
-			<directory>${basedir}/.././</directory>
+			<directory>${basedir}/</directory>
 			<includes>
 				<include>DISCLAIMER</include>
 			</includes>


### PR DESCRIPTION
update the dolphinscheduler-binary.xml file add DISCLAIMER file to binary tar .